### PR TITLE
fix:  `any` struct field copy

### DIFF
--- a/deep.go
+++ b/deep.go
@@ -201,7 +201,7 @@ func recursiveCopyStruct(v reflect.Value, pointers map[uintptr]interface{},
 		// can actually write to it.
 		disableRO(&dstField)
 
-		if dstField.Interface() == nil {
+		if elemDst == nil {
 			// Naked nil value, just continue.
 			continue
 		}

--- a/deep_test.go
+++ b/deep_test.go
@@ -117,7 +117,7 @@ func TestCopy_Slice_Error(t *testing.T) {
 }
 
 func TestCopy_Any_MapStringAny(t *testing.T) {
-	doCopyAndCheck(t, map[string]any{"key": 123}, false)
+	doCopyAndCheck(t, any(map[string]any{"key": 123}), false)
 }
 
 func TestCopy_Struct(t *testing.T) {

--- a/deep_test.go
+++ b/deep_test.go
@@ -196,6 +196,22 @@ func TestCopy_DerivedType(t *testing.T) {
 	doCopyAndCheck(t, S(42), false)
 }
 
+func TestCopy_Struct_With_Any_Field(t *testing.T) {
+	type S struct {
+		A any
+	}
+
+	src := S{A: map[string]interface{}{"key1": "value1", "key2": 12345}}
+	dst, err := Copy(src)
+	if err != nil {
+		t.Errorf("Copy failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(src, dst) {
+		t.Errorf("Copy failed: expected %v, got %v", src, dst)
+	}
+}
+
 func TestCopySkipUnsupported(t *testing.T) {
 	type S struct {
 		A int
@@ -238,22 +254,6 @@ func TestMustCopy_Error(t *testing.T) {
 	}()
 
 	MustCopy(func() {})
-}
-
-func TestCopyStructWithAnyField(t *testing.T) {
-	type S struct {
-		A any
-	}
-
-	src := S{A: map[string]interface{}{"key1": "value1", "key2": 12345}}
-	dst, err := Copy(src)
-	if err != nil {
-		t.Errorf("Copy failed: %v", err)
-	}
-
-	if !reflect.DeepEqual(src, dst) {
-		t.Errorf("Copy failed: expected %v, got %v", src, dst)
-	}
 }
 
 func doCopyAndCheck[T any](t *testing.T, src T, expectError bool) {

--- a/deep_test.go
+++ b/deep_test.go
@@ -240,6 +240,22 @@ func TestMustCopy_Error(t *testing.T) {
 	MustCopy(func() {})
 }
 
+func TestCopyStructWithAnyField(t *testing.T) {
+	type S struct {
+		A any
+	}
+
+	src := S{A: map[string]interface{}{"key1": "value1", "key2": 12345}}
+	dst, err := Copy(src)
+	if err != nil {
+		t.Errorf("Copy failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(src, dst) {
+		t.Errorf("Copy failed: expected %v, got %v", src, dst)
+	}
+}
+
 func doCopyAndCheck[T any](t *testing.T, src T, expectError bool) {
 	t.Helper()
 

--- a/deep_test.go
+++ b/deep_test.go
@@ -116,6 +116,10 @@ func TestCopy_Slice_Error(t *testing.T) {
 	doCopyAndCheck(t, []func(){func() {}}, true)
 }
 
+func TestCopy_Any_MapStringAny(t *testing.T) {
+	doCopyAndCheck(t, map[string]any{"key": 123}, false)
+}
+
 func TestCopy_Struct(t *testing.T) {
 	type S struct {
 		A int
@@ -202,14 +206,7 @@ func TestCopy_Struct_With_Any_Field(t *testing.T) {
 	}
 
 	src := S{A: map[string]interface{}{"key1": "value1", "key2": 12345}}
-	dst, err := Copy(src)
-	if err != nil {
-		t.Errorf("Copy failed: %v", err)
-	}
-
-	if !reflect.DeepEqual(src, dst) {
-		t.Errorf("Copy failed: expected %v, got %v", src, dst)
-	}
+	doCopyAndCheck(t, src, false)
 }
 
 func TestCopySkipUnsupported(t *testing.T) {


### PR DESCRIPTION
fixes #1 

- Adds test for struct with any fields that are actually json map[string]any
- Adds test for any type that are actually json map[string]any