### PR TITLE
Fix copy of nil slice.

### DIFF
--- a/deep.go
+++ b/deep.go
@@ -159,6 +159,11 @@ func recursiveCopyPtr(v reflect.Value, pointers map[uintptr]reflect.Value,
 
 func recursiveCopySlice(v reflect.Value, pointers map[uintptr]reflect.Value,
 	skipUnsupported bool) (reflect.Value, error) {
+	if v.IsNil() {
+		// If the slice is nil, just return it.
+		return v, nil
+	}
+
 	dst := reflect.MakeSlice(v.Type(), v.Len(), v.Cap())
 
 	for i := 0; i < v.Len(); i++ {

--- a/deep_test.go
+++ b/deep_test.go
@@ -109,6 +109,11 @@ func TestCopy_Slice(t *testing.T) {
 	doCopyAndCheck(t, []int{42, 43, 44, 45}, false)
 }
 
+func TestCopy_Slice_Nil(t *testing.T) {
+	var S []int
+	doCopyAndCheck(t, S, false)
+}
+
 func TestCopy_Slice_Error(t *testing.T) {
 	doCopyAndCheck(t, []func(){func() {}}, true)
 }


### PR DESCRIPTION
- The copy ended up with an empty (not nil) slice.
- Fixes issue #5.

Thanks Jan Fredrik Leversund for the bug report and fix.