### PR TITLE
Fix copy of nil map.

### DIFF
--- a/deep.go
+++ b/deep.go
@@ -112,6 +112,11 @@ func recursiveCopyInterface(v reflect.Value, pointers map[uintptr]reflect.Value,
 
 func recursiveCopyMap(v reflect.Value, pointers map[uintptr]reflect.Value,
 	skipUnsupported bool) (reflect.Value, error) {
+	if v.IsNil() {
+		// If the slice is nil, just return it.
+		return v, nil
+	}
+
 	dst := reflect.MakeMap(v.Type())
 
 	for _, key := range v.MapKeys() {

--- a/deep_test.go
+++ b/deep_test.go
@@ -90,6 +90,11 @@ func TestCopy_Map_Error(t *testing.T) {
 	doCopyAndCheck(t, map[int]func(){0: func() {}}, true)
 }
 
+func TestCopy_Map_Nil(t *testing.T) {
+	var m map[int]int
+	doCopyAndCheck(t, m, false)
+}
+
 func TestCopy_Ptr(t *testing.T) {
 	value := 42
 	doCopyAndCheck(t, &value, false)


### PR DESCRIPTION
- The copy ended up with an empty (not nil) map.