### PR TITLE
Correctly handle 2 values with different types but same pointers.

### DIFF
--- a/deep_test.go
+++ b/deep_test.go
@@ -340,3 +340,18 @@ func BenchmarkCopy_Deep(b *testing.B) {
 		MustCopy(src)
 	}
 }
+
+func TestTrickyMemberPointer(t *testing.T) {
+	type Foo struct {
+		N int
+	}
+	type Bar struct {
+		F *Foo
+		P *int
+	}
+
+	foo := Foo{N: 1}
+	bar := Bar{F: &foo, P: &foo.N}
+
+	doCopyAndCheck(t, bar, false)
+}


### PR DESCRIPTION
- This happens, for example, with a pointer to a struct and a pointer to the first member of that struct.
- This increase the number of allocations and the time per operation. We might need to find a better way to do this.
- Fixes issue #9.